### PR TITLE
Add 43tet and 50tet tunings

### DIFF
--- a/synth_control.cpp
+++ b/synth_control.cpp
@@ -487,6 +487,12 @@ class Instrument {
                         case (29): { // set 31tet tuning
                             set_notegen1(6.96774193548387f);
                         } return;
+                        case (31): { // set 43tet tuning
+                            set_notegen1(6.97674418604651f);
+                        } return;
+                        case (33): { // set 50tet tuning
+                            set_notegen1(6.96f);
+                        } return;
                         // row 6: 35 37 39 41 43 45 30 32
 #ifdef USE_MIDI_OUT
                         case (35): {
@@ -1267,7 +1273,9 @@ void update_leds(void) {
     // base color depending on tuning system
     if (dis.notegen1 < 6.94)       {r = 1; g = 0; b = 1;}
     else if (dis.notegen1 < 6.957) {r = 0; g = 0; b = 2;}
-    else if (dis.notegen1 < 6.984) {r = 0; g = 1; b = 1;}
+    else if (dis.notegen1 < 6.961) {r = 1; g = 1; b = 2;}
+    else if (dis.notegen1 < 6.968) {r = 0; g = 1; b = 1;}
+    else if (dis.notegen1 < 6.977) {r = 1; g = 2; b = 0;}
     else if (dis.notegen1 < 7.010) {r = 0; g = 2; b = 0;}
     else if (dis.notegen1 < 7.03)  {r = 1; g = 1; b = 0;}
     else                           {r = 2; g = 0; b = 0;}


### PR DESCRIPTION
I quickly added support for a couple additional meantone tunings that people might like to have available, since there were a couple buttons to spare in the tuning row. 43tet makes maj7 chords really pretty, since its E-F semitone is only 0.1 cents off from 16/15, and it's probably the more important of the two here.

As for why 50, well, I'm not sure, it's just another point on the meantone line that I've been rather fond of lately, but if someone wants to champion something different I'd be happy to give up the spot. :)

If you have some other idea for future use of these buttons, no worries, in any case, it was quite an easy change to make. Thanks very much for making the firmware open source!